### PR TITLE
FS-1236: chore(codeowners): add enrichment-maintainer as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @tink-ab/enrichment-maintainer
+


### PR DESCRIPTION
The Enrichment team maintains this fork. Added enrichment-maintainer as CODEOWNER.